### PR TITLE
Disable string intern caching

### DIFF
--- a/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
+++ b/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
@@ -149,7 +149,7 @@ public class JsonSerDe extends AbstractSerDe {
       throw new SerDeException(e);
     }
 
-    jsonFactory = new JsonFactory();
+    jsonFactory = new JsonFactory().disable(JsonParser.Feature.CANONICALIZE_FIELD_NAMES);
     tsParser = new TimestampParser(
         HiveStringUtils.splitAndUnEscape(tbl.getProperty(serdeConstants.TIMESTAMP_FORMATS)));
   }


### PR DESCRIPTION
We observed an issue of parallelism with HCatalog SerDe being locked in multiple threads on:

"20200722_101426_03468_nj6zh.2.16-10-1625" - Thread t@1625
java.lang.Thread.State: BLOCKED
at io.prestosql.hive.$internal.org.codehaus.jackson.util.InternCache.intern(InternCache.java:39)

waiting to lock <295b0f6> (a io.prestosql.hive.$internal.org.codehaus.jackson.util.InternCache) owned by "20200722_083806_02527_nj6zh.5.16-3004-24721" t@24721
In turn causing low CPU utilization.

After this change we tested on tpch data with 2x m5.xlarge12 workers on each cluster:
Comparison: (nointern/vanilla)
parallelism: 37 / 4 (!)
number of rows: 6M / 422K
CPU utlization: ~85% /10%

The downside of disabling string intern caching should be assessed