### PR TITLE
Add Hadoop LZO codec shim

### DIFF
--- a/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzoCodec.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hadoop.compression.lzo;
+
+//  Certain file formats store codec class name within file header section
+//  (e.g. sequence file) and provide no clean way for providing custom codec
+//  factory.
+public class LzoCodec
+        extends io.airlift.compress.lzo.LzoCodec {}


### PR DESCRIPTION
Certain file formats store codec class name within file header section
(e.g. sequence file) and provide no clean way for providing custom code
factory.