### PR TITLE
Fix JsonSerDe parsing performance

### DIFF
--- a/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
+++ b/src/main/java/org/apache/hive/hcatalog/data/JsonSerDe.java
@@ -18,7 +18,6 @@
  */
 package org.apache.hive.hcatalog.data;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.CharacterCodingException;
 import java.util.ArrayList;
@@ -168,7 +167,7 @@ public class JsonSerDe extends AbstractSerDe {
     JsonParser p;
     List<Object> r = new ArrayList<Object>(Collections.nCopies(columnNames.size(), null));
     try {
-      p = jsonFactory.createJsonParser(new ByteArrayInputStream((t.getBytes())));
+      p = jsonFactory.createJsonParser(t.getBytes(), 0, t.getLength());
       if (p.nextToken() != JsonToken.START_OBJECT) {
         throw new IOException("Start token not found where expected");
       }


### PR DESCRIPTION
Extracted changes from https://github.com/prestodb/presto-hive-apache/pull/44 to improve performance lost by disabling field name canonicalization in https://github.com/trinodb/trino-hive-apache/pull/12. Also improves performance by ensuring the parser starts with a populated canonicalized field name cache.

The following benchmarks were generated by doing a single threaded deserialization of a TPCH orders row like:
`{"o_orderkey":12000033,"o_custkey":436753,"o_orderstatus":"O","o_totalprice":19929.93,"o_orderdate":"1995-09-25","o_orderpriority":"4-NOT SPECIFIED","o_clerk":"Clerk#000006581","o_shippriority":0,"o_comment":"st the ironic pinto beans. final excuses use carefully fi"}`

Each was tested with field name canonicalization disabled (`NONE`), field name canonicalization only without interning, and with canonicalization + interning.

## Benchmark without calling JsonParser#close()
```
Benchmark                                                                         (mode)  Mode  Cnt      Score      Error   Units
BenchmarkJsonSerDe.benchmarkDeserialize                                             NONE  avgt    5   3663.276 ± 4229.735   ns/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate                              NONE  avgt    5   3305.522 ± 3114.044  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate.norm                         NONE  avgt    5  14984.001 ±    0.001    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space                     NONE  avgt    5   3329.810 ± 3127.963  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space.norm                NONE  avgt    5  15094.395 ±  362.167    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen                        NONE  avgt    5      0.005 ±    0.011  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen.norm                   NONE  avgt    5      0.021 ±    0.032    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.count                                   NONE  avgt    5    128.000             counts
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.time                                    NONE  avgt    5     99.000                 ms
BenchmarkJsonSerDe.benchmarkDeserialize                                CANONICALIZE_ONLY  avgt    5   2377.115 ±  192.259   ns/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate                 CANONICALIZE_ONLY  avgt    5   2418.667 ±  190.513  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate.norm            CANONICALIZE_ONLY  avgt    5   7544.000 ±    0.001    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space        CANONICALIZE_ONLY  avgt    5   2430.582 ±  291.562  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space.norm   CANONICALIZE_ONLY  avgt    5   7582.278 ±  882.890    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen           CANONICALIZE_ONLY  avgt    5      0.012 ±    0.014  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen.norm      CANONICALIZE_ONLY  avgt    5      0.038 ±    0.042    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.count                      CANONICALIZE_ONLY  avgt    5    115.000             counts
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.time                       CANONICALIZE_ONLY  avgt    5     66.000                 ms
BenchmarkJsonSerDe.benchmarkDeserialize                               INTERN_FIELD_NAMES  avgt    5   2396.886 ±  117.069   ns/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate                INTERN_FIELD_NAMES  avgt    5   2330.113 ±  108.808  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate.norm           INTERN_FIELD_NAMES  avgt    5   7328.000 ±    0.001    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space       INTERN_FIELD_NAMES  avgt    5   2345.421 ±  181.900  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space.norm  INTERN_FIELD_NAMES  avgt    5   7376.616 ±  578.085    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen          INTERN_FIELD_NAMES  avgt    5      0.011 ±    0.006  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen.norm     INTERN_FIELD_NAMES  avgt    5      0.035 ±    0.017    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.count                     INTERN_FIELD_NAMES  avgt    5    111.000             counts
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.time                      INTERN_FIELD_NAMES  avgt    5     67.000                 ms
```

## Benchmark with JsonParser#close()
```
Benchmark                                                                         (mode)  Mode  Cnt      Score     Error   Units
BenchmarkJsonSerDe.benchmarkDeserialize                                             NONE  avgt    5   2327.253 ±  99.673   ns/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate                              NONE  avgt    5   3437.489 ± 146.683  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate.norm                         NONE  avgt    5  10496.000 ±   0.001    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space                     NONE  avgt    5   3466.970 ± 322.884  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space.norm                NONE  avgt    5  10584.941 ± 584.081    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen                        NONE  avgt    5      0.007 ±   0.006  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen.norm                   NONE  avgt    5      0.021 ±   0.017    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.count                                   NONE  avgt    5    164.000            counts
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.time                                    NONE  avgt    5     93.000                ms
BenchmarkJsonSerDe.benchmarkDeserialize                                CANONICALIZE_ONLY  avgt    5   1390.603 ±  34.364   ns/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate                 CANONICALIZE_ONLY  avgt    5    907.602 ±  22.341  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate.norm            CANONICALIZE_ONLY  avgt    5   1656.000 ±   0.001    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space        CANONICALIZE_ONLY  avgt    5    905.509 ± 154.385  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space.norm   CANONICALIZE_ONLY  avgt    5   1652.249 ± 286.032    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen           CANONICALIZE_ONLY  avgt    5      0.003 ±   0.004  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen.norm      CANONICALIZE_ONLY  avgt    5      0.006 ±   0.007    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.count                      CANONICALIZE_ONLY  avgt    5     62.000            counts
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.time                       CANONICALIZE_ONLY  avgt    5     33.000                ms
BenchmarkJsonSerDe.benchmarkDeserialize                               INTERN_FIELD_NAMES  avgt    5   1364.882 ± 117.425   ns/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate                INTERN_FIELD_NAMES  avgt    5    924.750 ±  77.906  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.alloc.rate.norm           INTERN_FIELD_NAMES  avgt    5   1656.000 ±   0.001    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space       INTERN_FIELD_NAMES  avgt    5    919.923 ± 153.774  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Eden_Space.norm  INTERN_FIELD_NAMES  avgt    5   1646.824 ± 156.666    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen          INTERN_FIELD_NAMES  avgt    5      0.003 ±   0.003  MB/sec
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.churn.G1_Old_Gen.norm     INTERN_FIELD_NAMES  avgt    5      0.005 ±   0.005    B/op
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.count                     INTERN_FIELD_NAMES  avgt    5     63.000            counts
BenchmarkJsonSerDe.benchmarkDeserialize:·gc.time                      INTERN_FIELD_NAMES  avgt    5     34.000                ms
```