### PR TITLE
Add Thrift statistics requests needed by transactional tables

### DIFF
--- a/bin/generate-sources.sh
+++ b/bin/generate-sources.sh
@@ -9,6 +9,6 @@ SOURCE_DIR=src/main/thrift
 TARGET_DIR=target/generated-sources/thrift
 rm -rf "${ROOT_DIR:?}/${TARGET_DIR}"
 mkdir -p "${ROOT_DIR}/${TARGET_DIR}"
-docker run -u "$(id -u)" -v "${ROOT_DIR}:/rundir" thrift:0.9.3 thrift -o /rundir/${TARGET_DIR} --gen java:beans,hashcode,generated_annotations=undated /rundir/${SOURCE_DIR}/hive_metastore.thrift
+docker run -u "$(id -u)" -v "${ROOT_DIR}:/rundir" thrift:0.9.3 thrift -o /rundir/${TARGET_DIR} --gen java:beans,generated_annotations=suppress /rundir/${SOURCE_DIR}/hive_metastore.thrift
 mv "${ROOT_DIR}/${TARGET_DIR}"/gen-javabean/* "${ROOT_DIR}/${TARGET_DIR}"
 rmdir "${ROOT_DIR}/${TARGET_DIR}"/gen-javabean

--- a/src/main/thrift/hive_metastore.thrift
+++ b/src/main/thrift/hive_metastore.thrift
@@ -590,6 +590,13 @@ struct AlterPartitionsResponse {
 struct SetPartitionsStatsRequest {
 1: required list<ColumnStatistics> colStats,
 2: optional bool needMerge //stats need to be merged with the existing stats
+3: optional i64 writeId=-1,         // writeId for the current query that updates the stats
+4: optional string validWriteIdList, // valid write id list for the table for which this struct is being sent
+5: required string engine //engine creating the current request
+}
+
+struct SetPartitionsStatsResponse {
+1: required bool result;
 }
 
 // schema of the table/query results etc.
@@ -1975,6 +1982,11 @@ service ThriftHiveMetastore extends fb303.FacebookService
   bool update_table_column_statistics(1:ColumnStatistics stats_obj) throws (1:NoSuchObjectException o1,
               2:InvalidObjectException o2, 3:MetaException o3, 4:InvalidInputException o4)
   bool update_partition_column_statistics(1:ColumnStatistics stats_obj) throws (1:NoSuchObjectException o1,
+              2:InvalidObjectException o2, 3:MetaException o3, 4:InvalidInputException o4)
+
+  SetPartitionsStatsResponse update_table_column_statistics_req(1:SetPartitionsStatsRequest req) throws (1:NoSuchObjectException o1,
+              2:InvalidObjectException o2, 3:MetaException o3, 4:InvalidInputException o4)
+  SetPartitionsStatsResponse update_partition_column_statistics_req(1:SetPartitionsStatsRequest req) throws (1:NoSuchObjectException o1,
               2:InvalidObjectException o2, 3:MetaException o3, 4:InvalidInputException o4)
 
   // get APIs return the column statistics corresponding to db_name, tbl_name, [part_name], col_name if


### PR DESCRIPTION
ANALYZE applied to a Hive transactional table fails because the
Hive metastore statistics update requests used by Trino don't
contain the writeId and validWriteIds string.  This commit adds
the additional structures and metastore methods needed to update
statistics for transactional tables.

This commit also makes a couple of changes to the generate-sources.sh
script that appear to be required.