### PR TITLE
Expose more ParquetMetadataConverter methods

### DIFF
--- a/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverterUtil.java
+++ b/src/main/java/org/apache/parquet/format/converter/ParquetMetadataConverterUtil.java
@@ -1,6 +1,7 @@
 package org.apache.parquet.format.converter;
 
 import org.apache.parquet.format.ConvertedType;
+import org.apache.parquet.format.LogicalType;
 import org.apache.parquet.format.SchemaElement;
 import org.apache.parquet.schema.LogicalTypeAnnotation;
 
@@ -11,5 +12,15 @@ public final class ParquetMetadataConverterUtil
     public static LogicalTypeAnnotation getLogicalTypeAnnotation(ParquetMetadataConverter parquetMetadataConverter, ConvertedType convertedType, SchemaElement schemaElement)
     {
         return parquetMetadataConverter.getLogicalTypeAnnotation(convertedType, schemaElement);
+    }
+
+    public static LogicalTypeAnnotation getLogicalTypeAnnotation(ParquetMetadataConverter parquetMetadataConverter, LogicalType logicalType)
+    {
+        return parquetMetadataConverter.getLogicalTypeAnnotation(logicalType);
+    }
+
+    public static LogicalType convertToLogicalType(ParquetMetadataConverter parquetMetadataConverter, LogicalTypeAnnotation logicalTypeAnnotation)
+    {
+        return parquetMetadataConverter.convertToLogicalType(logicalTypeAnnotation);
     }
 }


### PR DESCRIPTION
Expose `convertToLogicalType()` and `getLogicalTypeAnnotation()`
overload.