### PR TITLE
Upgrade parquet version to 1.12.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <dep.avro.version>1.10.2</dep.avro.version>
         <dep.hadoop.version>3.1.4</dep.hadoop.version>
-        <dep.parquet.version>1.12.0</dep.parquet.version>
+        <dep.parquet.version>1.12.1</dep.parquet.version>
         <dep.protobuf.version>2.5.0</dep.protobuf.version>
         <dep.slf4j.version>1.7.29</dep.slf4j.version>
     </properties>


### PR DESCRIPTION
Parquet 1.12.1 is just released. It includes important [fixes](https://github.com/apache/parquet-mr/blob/parquet-1.12.x/CHANGES.md) particularly important fix https://issues.apache.org/jira/browse/PARQUET-2078. 