### PR TITLE
Upgrade Parquet version to 1.12.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <dep.avro.version>1.10.2</dep.avro.version>
         <dep.hadoop.version>3.1.4</dep.hadoop.version>
-        <dep.parquet.version>1.12.1</dep.parquet.version>
+        <dep.parquet.version>1.12.2</dep.parquet.version>
         <dep.protobuf.version>2.5.0</dep.protobuf.version>
         <dep.slf4j.version>1.7.29</dep.slf4j.version>
     </properties>


### PR DESCRIPTION
Parquet 1.12.2 has a [critical fix ](https://github.com/apache/parquet-mr/commit/afb64b8566204776081cfc56997cf8432b9491b4). It is important that Presto has that fix. 