### PR TITLE
Remove exclusion of commons-compress for Avro

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -504,10 +504,6 @@
                     <groupId>org.xerial.snappy</groupId>
                     <artifactId>snappy-java</artifactId>
                 </exclusion>
-                <exclusion>
-                    <groupId>org.apache.commons</groupId>
-                    <artifactId>commons-compress</artifactId>
-                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
This dependency is used at runtime:

```
java.lang.NoClassDefFoundError: io/trino/hive/$internal/org/apache/commons/compress/utils/IOUtils
	at org.apache.avro.file.ZstandardCodec.decompress(ZstandardCodec.java:85)
	at org.apache.avro.file.DataFileStream$DataBlock.decompressUsing(DataFileStream.java:380)
	at org.apache.avro.file.DataFileStream.hasNext(DataFileStream.java:214)
	at org.apache.hadoop.hive.ql.io.avro.AvroGenericRecordReader.next(AvroGenericRecordReader.java:206)
	at org.apache.hadoop.hive.ql.io.avro.AvroGenericRecordReader.next(AvroGenericRecordReader.java:59)
	at io.trino.plugin.hive.GenericHiveRecordCursor.advanceNextPosition(GenericHiveRecordCursor.java:215)
	at io.trino.plugin.hive.util.ForwardingRecordCursor.advanceNextPosition(ForwardingRecordCursor.java:46)
	at io.trino.spi.connector.RecordPageSource.getNextPage(RecordPageSource.java:88)
	at io.trino.operator.TableScanOperator.getOutput(TableScanOperator.java:311)
	at io.trino.operator.Driver.processInternal(Driver.java:388)
	at io.trino.operator.Driver.lambda$processFor$9(Driver.java:292)
	at io.trino.operator.Driver.tryWithLock(Driver.java:682)
	at io.trino.operator.Driver.processFor(Driver.java:285)
	at io.trino.execution.SqlTaskExecution$DriverSplitRunner.processFor(SqlTaskExecution.java:1076)
	at io.trino.execution.executor.PrioritizedSplitRunner.process(PrioritizedSplitRunner.java:163)
	at io.trino.execution.executor.TaskExecutor$TaskRunner.run(TaskExecutor.java:488)
	at io.trino.$gen.Trino_369____20220203_171909_2.run(Unknown Source)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
	at java.base/java.lang.Thread.run(Thread.java:829)
Caused by: java.lang.ClassNotFoundException: io.trino.hive.$internal.org.apache.commons.compress.utils.IOUtils
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:589)
	at io.trino.server.PluginClassLoader.loadClass(PluginClassLoader.java:89)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
	... 20 more