### PR TITLE
Add thrift parameters to compatible with Apache Hive 4.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>io.trino.hive</groupId>
     <artifactId>hive-apache</artifactId>
-    <version>3.1.2-21-SNAPSHOT</version>
+    <version>3.1.2-21-pr41-1-SNAPSHOT</version>
 
     <name>hive-apache</name>
     <description>Shaded version of Apache Hive for Trino</description>

--- a/src/main/thrift/hive_metastore.thrift
+++ b/src/main/thrift/hive_metastore.thrift
@@ -567,6 +567,8 @@ struct ColumnStatisticsDesc {
 struct ColumnStatistics {
 1: required ColumnStatisticsDesc statsDesc,
 2: required list<ColumnStatisticsObj> statsObj;
+3: optional bool isStatsCompliant,
+4: optional string engine = "hive" // Use hive stats
 }
 
 struct AggrStats {
@@ -736,6 +738,8 @@ struct TableStatsRequest {
  2: required string tblName,
  3: required list<string> colNames
  4: optional string catName
+ 5: optional string validWriteIdList,
+ 6: optional string engine = "hive" // Use hive stats
 }
 
 struct PartitionsStatsRequest {
@@ -744,6 +748,8 @@ struct PartitionsStatsRequest {
  3: required list<string> colNames,
  4: required list<string> partNames,
  5: optional string catName
+ 6: optional string validWriteIdList,
+ 7: optional string engine = "hive" // Use hive stats
 }
 
 // Return type for add_partitions_req


### PR DESCRIPTION
I am playing Trino with Apache Hive 4.0, and find that Cloudera CDP and Apache Hive 4.0 have some compatibility issues with Trino engine. These compatibility issues are mainly about hive statistics:

1. Trino use Hive 3.X  hive_metastore.thrift. Hive 4.0 made some incompatible changes about hive_metastore.thrift. eg:
 https://issues.apache.org/jira/browse/HIVE-22046 **Add engine field to differentiate among column stats by different engines**
 https://issues.apache.org/jira/browse/HIVE-22017 **Add ValidWriteIdList field to some methods(Mainly used for metadata cache or acid table)**

2. Trino update hive acid table(partitions) statistics failed because Hive 4.0 added a new method to update acid table and deprecated previous method :
Trino invoke method to update acid and non-acid table statistics:
https://github.com/trinodb/trino/blob/058904c4c59bbbc8cbe40b88decee48e8cfe8c37/plugin/trino-hive/src/main/java/io/trino/plugin/hive/metastore/thrift/ThriftHiveMetastoreClient.java#L227-L232

     Hive4.0 deprecated API, won't work for acid tables:
https://github.com/apache/hive/blob/248ce4aa5ee079850b9d81e737493a1309485521/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java#L6956-L6958
Hive4.0 added new API for acid tables:
https://github.com/apache/hive/blob/248ce4aa5ee079850b9d81e737493a1309485521/standalone-metastore/metastore-server/src/main/java/org/apache/hadoop/hive/metastore/HMSHandler.java#L7281-L7282

**Solution**
For issue 1, we can add missing thrift parameters in hive_metastore.thrift to fit for Hive 4.0, mainly engine and ValidWriteIdList fields. I have verify that non-acid hive4 table work well with this PR.

For issuse 2 which affect hive4 acid table, we shoud judge Hive version(Hive3 or Hive4) in _ThriftHiveMetastoreClient.java_ and then determine to invoke which update statistics method.