### PR TITLE
Upgrade Parquet version to 1.12.3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -654,7 +654,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>2.3</version>
+                <version>3.2.4</version>
                 <executions>
                     <execution>
                         <phase>package</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
 
         <dep.avro.version>1.10.2</dep.avro.version>
         <dep.hadoop.version>3.1.4</dep.hadoop.version>
-        <dep.parquet.version>1.12.2</dep.parquet.version>
+        <dep.parquet.version>1.12.3</dep.parquet.version>
         <dep.protobuf.version>2.5.0</dep.protobuf.version>
         <dep.slf4j.version>1.7.29</dep.slf4j.version>
     </properties>


### PR DESCRIPTION
Upgraded maven-shade-plugin because previous version was causing `Error creating shaded jar: null: IllegalArgumentException` in local builds.

Parquet upgrade contains https://issues.apache.org/jira/browse/PARQUET-2106 which benefits writes in Trino as well.