### PR TITLE
Add Hadoop LZOP codec shim

### DIFF
--- a/src/main/java/com/hadoop/compression/lzo/LzopCodec.java
+++ b/src/main/java/com/hadoop/compression/lzo/LzopCodec.java
@@ -1,0 +1,24 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.hadoop.compression.lzo;
+
+//  Certain file formats store codec class name within file header section
+//  (e.g. sequence file) and provide no clean way for providing custom codec
+//  factory.
+public class LzopCodec
+        extends io.airlift.compress.lzo.LzopCodec {}


### PR DESCRIPTION
Similar to https://github.com/trinodb/trino-hive-apache/pull/22

We got internal failures with below stack trace - 
```
Query 20230210_034746_00017_3sddv failed: Unable to create input format org.apache.hadoop.mapred.TextInputFormat
io.trino.spi.TrinoException: Unable to create input format org.apache.hadoop.mapred.TextInputFormat
        at io.trino.plugin.hive.util.HiveUtil.getInputFormat(HiveUtil.java:373)
        at io.trino.plugin.hive.BackgroundHiveSplitLoader.loadPartition(BackgroundHiveSplitLoader.java:419)
        at io.trino.plugin.hive.BackgroundHiveSplitLoader.loadSplits(BackgroundHiveSplitLoader.java:382)
        at io.trino.plugin.hive.BackgroundHiveSplitLoader$HiveSplitLoaderTask.process(BackgroundHiveSplitLoader.java:296)
        at io.trino.plugin.hive.util.ResumableTasks$1.run(ResumableTasks.java:38)
        at io.trino.$gen.Trino_dev____20230210_032112_2.run(Unknown Source)
        at io.airlift.concurrent.BoundedExecutor.drainQueue(BoundedExecutor.java:80)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
        at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.lang.RuntimeException: Error in configuring object
        at org.apache.hadoop.util.ReflectionUtils.setJobConf(ReflectionUtils.java:113)
        at org.apache.hadoop.util.ReflectionUtils.setConf(ReflectionUtils.java:79)
        at org.apache.hadoop.util.ReflectionUtils.newInstance(ReflectionUtils.java:137)
        at io.trino.plugin.hive.util.HiveUtil.getInputFormat(HiveUtil.java:370)
        ... 9 more
Caused by: java.lang.reflect.InvocationTargetException
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:568)
        at org.apache.hadoop.util.ReflectionUtils.setJobConf(ReflectionUtils.java:110)
        ... 12 more
Caused by: java.lang.IllegalArgumentException: Compression codec com.hadoop.compression.lzo.LzopCodec not found.
        at org.apache.hadoop.io.compress.CompressionCodecFactory.getCodecClasses(CompressionCodecFactory.java:139)
        at org.apache.hadoop.io.compress.CompressionCodecFactory.<init>(CompressionCodecFactory.java:180)
        at org.apache.hadoop.mapred.TextInputFormat.configure(TextInputFormat.java:45)
        ... 17 more
Caused by: java.lang.ClassNotFoundException: Class com.hadoop.compression.lzo.LzopCodec not found
        at org.apache.hadoop.conf.Configuration.getClassByName(Configuration.java:2334)
        at org.apache.hadoop.io.compress.CompressionCodecFactory.getCodecClasses(CompressionCodecFactory.java:132)
        ... 19 more
```

cc @findepi @phd3 